### PR TITLE
Improve start page flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# petmemorials
+# Pet Memorials
+
+This project is a small proof‑of‑concept service that lets users create short memorial pages by scanning a QR code. It consists of a small Flask back‑end and a simple React front‑end.
+
+## Running locally
+
+1. Install Python dependencies:
+
+```bash
+pip install -r requirement.txt
+```
+
+2. Start the development server:
+
+```bash
+python main.py
+```
+
+The app will run on `http://localhost:8001`. Opening `/start` loads the main page.
+
+## Features
+
+- Create a memorial page with an optional short code
+- Upload images and videos (limits depend on plan)
+- Pages are associated with a device ID stored in `localStorage`
+- Returning users are redirected to their page if only one exists
+
+This repository only provides basic UI styling and mock premium subscription logic. It is meant as a minimal demonstration rather than a production ready service.

--- a/StartPage.jsx
+++ b/StartPage.jsx
@@ -24,9 +24,14 @@ const StartPage = ({ onNavigateToMemorial }) => {
     try {
       const response = await getMemorialPagesByDevice();
       if (response.success) {
-        setMemorialPages(response.data);
-        // Remove auto-redirect to create form for new users
-        // Always show the main page with search option and create button
+        const pages = response.data;
+        setMemorialPages(pages);
+
+        if (pages.length === 0) {
+          setShowCreateForm(true);
+        } else if (pages.length === 1) {
+          onNavigateToMemorial(pages[0].code);
+        }
       }
     } catch (error) {
       console.error('Error loading memorial pages:', error);


### PR DESCRIPTION
## Summary
- automatically open create form for new users and redirect when only one memorial page exists
- document running the Flask/React demo

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688057cd70dc8331b1835b245da71a4c